### PR TITLE
AHash feature, Rust edition 2021, cargo fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dot_vox"
 version = "4.1.0"
+edition = "2021"
 authors = ["David Edmonds <edmonds.d.r@gmail.com>"]
 description = "A Rust library for loading MagicaVoxel .vox files."
 license = "MIT"
@@ -10,9 +11,13 @@ homepage = "https://docs.rs/dot_vox"
 repository = "https://github.com/davidedmonds/dot_vox"
 readme = "README.md"
 
+[features]
+default = ["ahash"]
+
 [dependencies]
-byteorder = "^1.0"
-lazy_static = "^1.0"
+ahash = { version = "0.7.4", optional = true }
+byteorder = "1.4.3"
+lazy_static = "1.4.0"
 log = "^0.4"
 nom = "^4.1"
 

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -1,4 +1,4 @@
-use {Material, Model};
+use crate::{Material, Model};
 
 use std::io::{self, Write};
 

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -38,7 +38,9 @@ impl DotVoxData {
     }
 
     fn write_main_chunk<W: Write>(
-        &self, writer: &mut W, num_children_bytes: u32
+        &self,
+        writer: &mut W,
+        num_children_bytes: u32,
     ) -> Result<(), io::Error> {
         Self::write_chunk(writer, "MAIN", &[], num_children_bytes)
     }
@@ -93,11 +95,7 @@ impl DotVoxData {
         Self::write_leaf_chunk(writer, "RGBA", &chunk)
     }
 
-    fn write_leaf_chunk<W: Write>(
-        writer: &mut W,
-        id: &str,
-        chunk: &[u8],
-    ) -> Result<(), io::Error> {
+    fn write_leaf_chunk<W: Write>(writer: &mut W, id: &str, chunk: &[u8]) -> Result<(), io::Error> {
         let num_children_bytes: u32 = 0;
 
         Self::write_chunk(writer, id, chunk, num_children_bytes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ extern crate nom;
 extern crate avow;
 
 mod dot_vox_data;
+mod model;
 mod palette;
 mod parser;
-mod model;
 
 pub use crate::dot_vox_data::DotVoxData;
 
@@ -38,17 +38,17 @@ use std::io::Read;
 
 /// Loads the supplied MagicaVoxel .vox file
 ///
-/// Loads the supplied file, parses it, and returns a `DotVoxData` containing 
-/// the version of the MagicaVoxel file, a `Vec<Model>` containing all `Model`s 
+/// Loads the supplied file, parses it, and returns a `DotVoxData` containing
+/// the version of the MagicaVoxel file, a `Vec<Model>` containing all `Model`s
 /// contained within the file, a `Vec<u32>` containing the palette information
 /// (RGBA), and a `Vec<Material>` containing all the specialized materials.
 ///
 /// # Panics
-/// No panics should occur with this library - if you find one, please raise a 
+/// No panics should occur with this library - if you find one, please raise a
 /// GitHub issue for it.
 ///
 /// # Errors
-/// All errors are strings, and should describe the issue that caused them to 
+/// All errors are strings, and should describe the issue that caused them to
 /// occur.
 ///
 /// # Examples
@@ -161,40 +161,59 @@ pub fn load_bytes(bytes: &[u8]) -> Result<DotVoxData, &'static str> {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use avow::vec;
+    use super::*;
+    use avow::vec;
 
     lazy_static! {
-      static ref DEFAULT_MATERIALS: Vec<Material> = (0..256).into_iter()
-        .map(|i| Material {
-            id: i,
-            properties: {
-                let mut map = Dict::new();
-                map.insert("_ior".to_owned(), "0.3".to_owned());
-                map.insert("_spec".to_owned(), "0.5".to_owned());
-                map.insert("_rough".to_owned(), "0.1".to_owned());
-                map.insert("_type".to_owned(), "_diffuse".to_owned());
-                map.insert("_weight".to_owned(), "1".to_owned());
-                map
-            }
-        })
-        .collect();
+        static ref DEFAULT_MATERIALS: Vec<Material> = (0..256)
+            .into_iter()
+            .map(|i| Material {
+                id: i,
+                properties: {
+                    let mut map = Dict::new();
+                    map.insert("_ior".to_owned(), "0.3".to_owned());
+                    map.insert("_spec".to_owned(), "0.5".to_owned());
+                    map.insert("_rough".to_owned(), "0.1".to_owned());
+                    map.insert("_type".to_owned(), "_diffuse".to_owned());
+                    map.insert("_weight".to_owned(), "1".to_owned());
+                    map
+                }
+            })
+            .collect();
     }
 
     fn placeholder(palette: Vec<u32>, materials: Vec<Material>) -> DotVoxData {
         DotVoxData {
             version: 150,
-            models: vec![
-                Model {
-                    size: Size { x: 2, y: 2, z: 2 },
-                    voxels: vec![
-                        Voxel { x: 0, y: 0, z: 0, i: 225 },
-                        Voxel { x: 0, y: 1, z: 1, i: 215 },
-                        Voxel { x: 1, y: 0, z: 1, i: 235 },
-                        Voxel { x: 1, y: 1, z: 0, i: 5 },
-                    ],
-                },
-            ],
+            models: vec![Model {
+                size: Size { x: 2, y: 2, z: 2 },
+                voxels: vec![
+                    Voxel {
+                        x: 0,
+                        y: 0,
+                        z: 0,
+                        i: 225,
+                    },
+                    Voxel {
+                        x: 0,
+                        y: 1,
+                        z: 1,
+                        i: 215,
+                    },
+                    Voxel {
+                        x: 1,
+                        y: 0,
+                        z: 1,
+                        i: 235,
+                    },
+                    Voxel {
+                        x: 1,
+                        y: 1,
+                        z: 0,
+                        i: 5,
+                    },
+                ],
+            }],
             palette: palette,
             materials: materials,
         }
@@ -219,8 +238,10 @@ mod tests {
     fn valid_file_with_palette_is_read_successfully() {
         let result = load("src/resources/placeholder.vox");
         assert!(result.is_ok());
-        compare_data(result.unwrap(), placeholder(DEFAULT_PALETTE.to_vec(),
-                                                  DEFAULT_MATERIALS.to_vec()));
+        compare_data(
+            result.unwrap(),
+            placeholder(DEFAULT_PALETTE.to_vec(), DEFAULT_MATERIALS.to_vec()),
+        );
     }
 
     #[test]
@@ -243,7 +264,10 @@ mod tests {
         let result = super::parse_vox_file(CompleteByteSlice(&bytes));
         assert!(result.is_ok());
         let (_, models) = result.unwrap();
-        compare_data(models, placeholder(DEFAULT_PALETTE.to_vec(), DEFAULT_MATERIALS.to_vec()));
+        compare_data(
+            models,
+            placeholder(DEFAULT_PALETTE.to_vec(), DEFAULT_MATERIALS.to_vec()),
+        );
     }
 
     #[test]
@@ -254,7 +278,7 @@ mod tests {
         assert!(result.is_ok());
         let (_, voxel_data) = result.unwrap();
         let mut materials: Vec<Material> = DEFAULT_MATERIALS.to_vec();
-        materials[216] = Material{
+        materials[216] = Material {
             id: 216,
             properties: {
                 let mut map = Dict::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,19 +19,19 @@ mod palette;
 mod parser;
 mod model;
 
-pub use dot_vox_data::DotVoxData;
+pub use crate::dot_vox_data::DotVoxData;
 
-pub use parser::{Dict, Material};
+pub use crate::parser::{Dict, Material};
 
-pub use model::Model;
-pub use model::Size;
-pub use model::Voxel;
+pub use crate::model::Model;
+pub use crate::model::Size;
+pub use crate::model::Voxel;
 
 use nom::types::CompleteByteSlice;
 
-pub use palette::DEFAULT_PALETTE;
+pub use crate::palette::DEFAULT_PALETTE;
 
-use parser::parse_vox_file;
+use crate::parser::parse_vox_file;
 
 use std::fs::File;
 use std::io::Read;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
 use nom::types::CompleteByteSlice;
-use ::parser::{le_u8, le_u32};
+use crate::parser::{le_u8, le_u32};
 
 /// A renderable voxel Model
 #[derive(Debug, PartialEq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,5 @@
+use crate::parser::{le_u32, le_u8};
 use nom::types::CompleteByteSlice;
-use crate::parser::{le_u8, le_u32};
 
 /// A renderable voxel Model
 #[derive(Debug, PartialEq)]

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,6 +1,6 @@
 use byteorder::{ByteOrder, LittleEndian};
 use nom::types::CompleteByteSlice;
-use ::parser::le_u32;
+use crate::parser::le_u32;
 
 lazy_static! {
   /// The default palette used by MagicaVoxel - this is supplied if no palette

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,6 +1,6 @@
+use crate::parser::le_u32;
 use byteorder::{ByteOrder, LittleEndian};
 use nom::types::CompleteByteSlice;
-use crate::parser::le_u32;
 
 lazy_static! {
   /// The default palette used by MagicaVoxel - this is supplied if no palette

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,11 +1,16 @@
-use {DEFAULT_PALETTE, DotVoxData, Model, model, palette, Size, Voxel};
+use crate::{DEFAULT_PALETTE, DotVoxData, Model, model, palette, Size, Voxel};
 use nom::IResult;
 use nom::types::CompleteByteSlice;
-use std::collections::HashMap;
 use std::str;
 use std::str::Utf8Error;
 
-const MAGIC_NUMBER: &'static str = "VOX ";
+#[cfg(feature = "ahash")]
+use ahash::AHashMap as HashMap;
+
+#[cfg(not(feature = "ahash"))]
+use std::collections::HashMap;
+
+const MAGIC_NUMBER: &str = "VOX ";
 
 #[derive(Debug, PartialEq)]
 pub enum Chunk {


### PR DESCRIPTION
* Added optional [`ahash`](https://crates.io/crates/ahash) dependency for faster hashing/lookups.
* Bumped code to Rust 2021.
* ran `cargo fmt`.
