### PR TITLE
Rollup changes from other Pull Requests into this one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 byteorder = "^1.0"
 lazy_static = "^1.0"
 log = "^0.4"
-nom = "^4.1"
+nom = "^5.1"
 
 [dev-dependencies]
 avow = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dot_vox"
 version = "4.1.0"
+edition = "2021"
 authors = ["David Edmonds <edmonds.d.r@gmail.com>"]
 description = "A Rust library for loading MagicaVoxel .vox files."
 license = "MIT"
@@ -18,4 +19,4 @@ nom = { version = "^7", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 avow = "0.2.0"
-env_logger = "^0.5"
+env_logger = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 byteorder = "^1.0"
 lazy_static = "^1.0"
 log = "^0.4"
-nom = "^5.1"
+nom = { version = "^7", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 avow = "0.2.0"

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -1,8 +1,8 @@
+use crate::{Layer, Material, Model, SceneNode};
 use std::io::{self, Write};
-use {Dict, Material, Model, SceneNode};
 
 /// Container for .vox file data
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DotVoxData {
     /// The version number of the .vox file.
     pub version: u32,
@@ -13,9 +13,9 @@ pub struct DotVoxData {
     /// A Vec containing all the Materials set
     pub materials: Vec<Material>,
     /// Scene. The first node in this list is always the root node.
-    pub scene: Vec<SceneNode>,
+    pub scenes: Vec<SceneNode>,
     /// Layers. Used by scene transform nodes.
-    pub layers: Vec<Dict>,
+    pub layers: Vec<Layer>,
 }
 
 impl DotVoxData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ extern crate env_logger;
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate nom;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@ pub use model::Model;
 pub use model::Size;
 pub use model::Voxel;
 
-use nom::types::CompleteByteSlice;
-
 pub use palette::DEFAULT_PALETTE;
 
 use parser::parse_vox_file;
@@ -153,7 +151,7 @@ pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
 ///   });
 /// ```
 pub fn load_bytes(bytes: &[u8]) -> Result<DotVoxData, &'static str> {
-    match parse_vox_file(CompleteByteSlice(bytes)) {
+    match parse_vox_file(bytes) {
         Ok((_, parsed)) => Ok(parsed),
         Err(_) => Err("Not a valid MagicaVoxel .vox file"),
     }
@@ -240,7 +238,7 @@ mod tests {
     #[test]
     fn can_parse_vox_file_with_palette() {
         let bytes = include_bytes!("resources/placeholder.vox").to_vec();
-        let result = super::parse_vox_file(CompleteByteSlice(&bytes));
+        let result = super::parse_vox_file(&bytes);
         assert!(result.is_ok());
         let (_, models) = result.unwrap();
         compare_data(models, placeholder(DEFAULT_PALETTE.to_vec(), DEFAULT_MATERIALS.to_vec()));
@@ -250,7 +248,7 @@ mod tests {
     fn can_parse_vox_file_with_materials() {
         let _log = env_logger::init();
         let bytes = include_bytes!("resources/placeholder-with-materials.vox").to_vec();
-        let result = super::parse_vox_file(CompleteByteSlice(&bytes));
+        let result = super::parse_vox_file(&bytes);
         assert!(result.is_ok());
         let (_, voxel_data) = result.unwrap();
         let mut materials: Vec<Material> = DEFAULT_MATERIALS.to_vec();

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,3 @@
-use nom::types::CompleteByteSlice;
 use ::parser::{le_u8, le_u32};
 
 /// A renderable voxel Model
@@ -48,14 +47,14 @@ pub struct Voxel {
     pub i: u8,
 }
 
-named!(pub parse_size <CompleteByteSlice, Size>, do_parse!(
+named!(pub parse_size <&[u8], Size>, do_parse!(
   x: le_u32 >>
   y: le_u32 >>
   z: le_u32 >>
   (Size { x, y, z })
 ));
 
-named!(parse_voxel <CompleteByteSlice, Voxel>, do_parse!(
+named!(parse_voxel <&[u8], Voxel>, do_parse!(
   x: le_u8 >>
   y: le_u8 >>
   z: le_u8 >>
@@ -63,7 +62,7 @@ named!(parse_voxel <CompleteByteSlice, Voxel>, do_parse!(
   (Voxel { x, y, z, i: i.saturating_sub(1) })
 ));
 
-named!(pub parse_voxels <CompleteByteSlice, Vec<Voxel> >, do_parse!(
+named!(pub parse_voxels <&[u8], Vec<Voxel> >, do_parse!(
   num_voxels: le_u32 >>
   voxels: many_m_n!(num_voxels as usize, num_voxels as usize, parse_voxel) >>
   (voxels)

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use ::parser::{le_u8, le_u32};
+use nom::number::streaming::{le_u8, le_u32};
 
 /// A renderable voxel Model
 #[derive(Debug, PartialEq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,10 +1,10 @@
 use nom::multi::count;
-use ::parser::{le_u8, le_u32};
+use nom::number::complete::{le_u32, le_u8};
 use nom::sequence::tuple;
 use nom::IResult;
 
 /// A renderable voxel Model
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Model {
     /// The size of the model in voxels
     pub size: Size,
@@ -22,7 +22,7 @@ impl Model {
 /// The size of a model in voxels
 ///
 /// Indicates the size of the model in Voxels.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Size {
     /// The width of the model in voxels.
     pub x: u32,
@@ -35,7 +35,7 @@ pub struct Size {
 /// A Voxel
 ///
 /// A Voxel is a point in 3D space, with an indexed colour attached.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Voxel {
     /// The X coordinate for the Voxel
     pub x: u8,
@@ -57,7 +57,15 @@ pub fn parse_size(i: &[u8]) -> IResult<&[u8], Size> {
 
 fn parse_voxel(input: &[u8]) -> IResult<&[u8], Voxel> {
     let (input, (x, y, z, i)) = tuple((le_u8, le_u8, le_u8, le_u8))(input)?;
-    Ok((input, Voxel { x, y, z, i: i.saturating_sub(1) }))
+    Ok((
+        input,
+        Voxel {
+            x,
+            y,
+            z,
+            i: i.saturating_sub(1),
+        },
+    ))
 }
 
 pub fn parse_voxels(i: &[u8]) -> IResult<&[u8], Vec<Voxel>> {

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,5 +1,4 @@
 use byteorder::{ByteOrder, LittleEndian};
-use nom::types::CompleteByteSlice;
 use ::parser::le_u32;
 
 lazy_static! {
@@ -12,7 +11,7 @@ lazy_static! {
         .collect();
 }
 
-named!(pub extract_palette <CompleteByteSlice, Vec<u32> >, do_parse!(
+named!(pub extract_palette <&[u8], Vec<u32> >, do_parse!(
     res: many_till!(le_u32, eof!()) >>
     (res.0)
 ));

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,5 +1,5 @@
 use byteorder::{ByteOrder, LittleEndian};
-use ::parser::le_u32;
+use nom::number::streaming::le_u32;
 
 lazy_static! {
   /// The default palette used by MagicaVoxel - this is supplied if no palette

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -2,7 +2,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use nom::combinator::all_consuming;
 use nom::multi::many0;
 use nom::number::complete::le_u32;
-use ::parser::le_u32;
+use nom::IResult;
 
 lazy_static! {
   /// The default palette used by MagicaVoxel - this is supplied if no palette

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,5 +1,8 @@
 use byteorder::{ByteOrder, LittleEndian};
-use nom::number::streaming::le_u32;
+use nom::combinator::all_consuming;
+use nom::multi::many0;
+use nom::number::complete::le_u32;
+use nom::IResult;
 
 lazy_static! {
   /// The default palette used by MagicaVoxel - this is supplied if no palette
@@ -11,7 +14,6 @@ lazy_static! {
         .collect();
 }
 
-named!(pub extract_palette <&[u8], Vec<u32> >, do_parse!(
-    res: many_till!(le_u32, eof!()) >>
-    (res.0)
-));
+pub fn extract_palette(i: &[u8]) -> IResult<&[u8], Vec<u32>> {
+    all_consuming(many0(le_u32))(i)
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 use {DEFAULT_PALETTE, DotVoxData, Model, model, palette, Size, Voxel};
+use nom::number::streaming::le_u32;
 use nom::IResult;
 use std::collections::HashMap;
 use std::str;
@@ -29,19 +30,6 @@ pub struct Material {
 
 /// General dictionary
 pub type Dict = HashMap<String, String>;
-
-/// Recognizes an unsigned 1 byte integer (equivalent to take!(1)
-#[inline]
-pub fn le_u8(i: &[u8]) -> IResult<&[u8], u8> {
-    Ok((&i[1..], i[0]))
-}
-
-/// Recognizes little endian unsigned 4 bytes integer
-#[inline]
-pub fn le_u32(i: &[u8]) -> IResult<&[u8], u32> {
-    let res = ((i[3] as u32) << 24) + ((i[2] as u32) << 16) + ((i[1] as u32) << 8) + i[0] as u32;
-    Ok((&i[4..], res))
-}
 
 pub fn to_str(i: &[u8]) -> Result<String, Utf8Error> {
     let res = str::from_utf8(i)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,7 @@
-use nom::types::CompleteByteSlice;
+use crate::{
+    model, palette, scene, DotVoxData, Layer, Model, SceneGroup, SceneNode, SceneShape,
+    SceneTransform, Size, Voxel, DEFAULT_PALETTE,
+};
 use nom::bytes::complete::{tag, take};
 use nom::combinator::{flat_map, map_res};
 use nom::multi::{fold_many_m_n, many0};
@@ -8,12 +11,10 @@ use nom::IResult;
 use std::collections::HashMap;
 use std::str;
 use std::str::Utf8Error;
-use {
-    model, palette, scene, DotVoxData, Layer, Model, SceneGroup, SceneNode, SceneShape,
-    SceneTransform, Size, Voxel, DEFAULT_PALETTE,
-};
 
-const MAGIC_NUMBER: &'static str = "VOX ";
+use crate::{Frame, RawLayer};
+
+const MAGIC_NUMBER: &str = "VOX ";
 
 #[derive(Debug, PartialEq)]
 pub enum Chunk {
@@ -26,31 +27,143 @@ pub enum Chunk {
     TransformNode(SceneTransform),
     GroupNode(SceneGroup),
     ShapeNode(SceneShape),
-    Layer(Layer),
+    Layer(RawLayer),
     Unknown(String),
     Invalid(Vec<u8>),
 }
 
 /// A material used to render this model.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Material {
-    /// The Material's ID
+    /// The Material's ID.  Corresponds to an index in the palette.
     pub id: u32,
     /// Properties of the material, mapped by property name.
     pub properties: Dict,
 }
 
-/// General dictionary
-pub type Dict = HashMap<String, String>;
+// TODO: maybe material schemas?
 
-/// Recognizes little endian signed 4 bytes integer
-#[inline]
-pub fn le_i32(i: CompleteByteSlice) -> IResult<CompleteByteSlice, i32> {
-    match le_u32(i) {
-        Ok(result) => Ok((CompleteByteSlice(&i[4..]), result.1 as i32)),
-        Err(e) => Err(e),
+impl Material {
+    /// The '_type' field, if present
+    pub fn material_type(&self) -> Option<&str> {
+        if let Some(t) = self.properties.get("_type") {
+            return Some(t.as_str());
+        }
+
+        None
+    }
+
+    /// The '_weight' field associated with the material
+    pub fn weight(&self) -> Option<f32> {
+        let w = self.get_f32("_weight");
+
+        if let Some(w) = w && (w < 0.0 || w > 1.0)
+        {
+            debug!("_weight observed outside of range of [0..1]: {}", w);
+        }
+
+        w
+    }
+
+    /// The '_metal' field associated with the material
+    pub fn metal(&self) -> Option<f32> {
+        self.get_f32("_metal")
+    }
+
+    /// The '_rough' field associated with the material
+    pub fn roughness(&self) -> Option<f32> {
+        self.get_f32("_rough")
+    }
+
+    /// The '_sp' field associated with the material.
+    /// The .vox specification lists this as "_spec".
+    pub fn specular(&self) -> Option<f32> {
+        self.get_f32("_sp")
+    }
+
+    /// The '_ior' field associated with the material
+    pub fn refractive_index(&self) -> Option<f32> {
+        self.get_f32("_ior")
+    }
+
+    /// The '_emit' field associated with the material
+    pub fn emit(&self) -> Option<f32> {
+        self.get_f32("_emit")
+    }
+
+    /// The '_ldr' field associated with the material
+    pub fn ldr(&self) -> Option<f32> {
+        self.get_f32("_ldr")
+    }
+
+    /// The '_ri' field associated with the material (appears to just be 1 + _ior)
+    pub fn ri(&self) -> Option<f32> {
+        self.get_f32("_ior")
+    }
+
+    /// The '_att' field associated with the material
+    pub fn att(&self) -> Option<f32> {
+        self.get_f32("_att")
+    }
+
+    /// The '_flux' field associated with the material
+    pub fn flux(&self) -> Option<f32> {
+        self.get_f32("_flux")
+    }
+
+    /// The '_g' field associated with the material
+    pub fn phase(&self) -> Option<f32> {
+        self.get_f32("_g")
+    }
+
+    /// The '_alpha' field associated with the material
+    pub fn alpha(&self) -> Option<f32> {
+        self.get_f32("_alpha")
+    }
+
+    /// The '_trans' field associated with the material.
+    /// Appears to share the same meaning as _alpha.
+    pub fn transparency(&self) -> Option<f32> {
+        self.get_f32("_trans")
+    }
+
+    /// The '_d' field associated with the material
+    pub fn density(&self) -> Option<f32> {
+        self.get_f32("_d")
+    }
+
+    /// The '_media' field associated with the material.
+    /// This corresponds to the 'cloud' material.
+    pub fn media(&self) -> Option<f32> {
+        self.get_f32("_media")
+    }
+
+    /// The '_media_type' field associated with the material.
+    /// Corresponds to the type of cloud: absorb, scatter, emissive, subsurface scattering
+    pub fn media_type(&self) -> Option<&str> {
+        if let Some(t) = self.properties.get("_media_type") {
+            return Some(t.as_str());
+        }
+
+        None
+    }
+
+    fn get_f32(&self, prop: &str) -> Option<f32> {
+        if let Some(t) = self.properties.get(prop) {
+            match t.parse::<f32>() {
+                Ok(x) => return Some(x),
+                Err(_) => {
+                    debug!("Could not parse float for property '{}': {}", prop, t)
+                }
+            }
+        }
+
+        None
     }
 }
+
+/// General dictionary
+pub type Dict = HashMap<String, String>;
 
 pub fn to_str(i: &[u8]) -> Result<String, Utf8Error> {
     let res = str::from_utf8(i)?;
@@ -72,7 +185,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
             let mut palette_holder: Vec<u32> = DEFAULT_PALETTE.to_vec();
             let mut materials: Vec<Material> = vec![];
             let mut scene: Vec<SceneNode> = vec![];
-            let mut layers: Vec<Dict> = vec![];
+            let mut layers: Vec<Layer> = Vec::new();
 
             for chunk in children {
                 match chunk {
@@ -88,7 +201,11 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                     Chunk::TransformNode(scene_transform) => {
                         scene.push(SceneNode::Transform {
                             attributes: scene_transform.header.attributes,
-                            frames: scene_transform.frames,
+                            frames: scene_transform
+                                .frames
+                                .into_iter()
+                                .map(|attributes| Frame::new(attributes))
+                                .collect(),
                             child: scene_transform.child,
                         });
                     }
@@ -100,7 +217,19 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                         attributes: scene_shape.header.attributes,
                         models: scene_shape.models,
                     }),
-                    Chunk::Layer(layer) => layers.push(layer.attributes),
+                    Chunk::Layer(layer) => {
+                        if layer.id as usize != layers.len() {
+                            // Not sure if this actually happens in practice, but nothing in the spec prohibits it.
+                            debug!(
+                                "Unexpected layer id {} encountered, layers may be out of order.",
+                                layer.id
+                            );
+                        }
+
+                        layers.push(Layer {
+                            attributes: layer.attributes,
+                        });
+                    }
                     _ => debug!("Unmapped chunk {:?}", chunk),
                 }
             }
@@ -110,7 +239,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                 models,
                 palette: palette_holder,
                 materials,
-                scene,
+                scenes: scene,
                 layers,
             }
         }
@@ -119,7 +248,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
             models: vec![],
             palette: vec![],
             materials: vec![],
-            scene: vec![],
+            scenes: vec![],
             layers: vec![],
         },
     }
@@ -134,12 +263,7 @@ fn parse_chunk(i: &[u8]) -> IResult<&[u8], Chunk> {
     Ok((i, chunk))
 }
 
-fn build_chunk(string: String,
-    string: String,
-               chunk_content: &[u8],
-    children_size: u32,
-               child_content: &[u8]) -> Chunk {
-) -> Chunk {
+fn build_chunk(id: &str, chunk_content: &[u8], children_size: u32, child_content: &[u8]) -> Chunk {
     if children_size == 0 {
         match id {
             "SIZE" => build_size_chunk(chunk_content),
@@ -190,6 +314,8 @@ fn build_palette_chunk(chunk_content: &[u8]) -> Chunk {
     Chunk::Invalid(chunk_content.to_vec())
 }
 
+// NOTE: this does not seem consistent with the PACK documentation.  However, files with PACK chunks seem rare.
+// It's likely this hasn't been tested.  Is this correct?
 fn build_pack_chunk(chunk_content: &[u8]) -> Chunk {
     if let Ok((chunk_content, Chunk::Size(size))) = parse_chunk(chunk_content) {
         if let Ok((_, Chunk::Voxels(voxels))) = parse_chunk(chunk_content) {
@@ -216,28 +342,28 @@ fn build_voxel_chunk(chunk_content: &[u8]) -> Chunk {
     }
 }
 
-fn build_scene_transform_chunk(chunk_content: CompleteByteSlice) -> Chunk {
+fn build_scene_transform_chunk(chunk_content: &[u8]) -> Chunk {
     match scene::parse_scene_transform(chunk_content) {
         Ok((_, transform_node)) => Chunk::TransformNode(transform_node),
         _ => Chunk::Invalid(chunk_content.to_vec()),
     }
 }
 
-fn build_scene_group_chunk(chunk_content: CompleteByteSlice) -> Chunk {
+fn build_scene_group_chunk(chunk_content: &[u8]) -> Chunk {
     match scene::parse_scene_group(chunk_content) {
         Ok((_, group_node)) => Chunk::GroupNode(group_node),
         _ => Chunk::Invalid(chunk_content.to_vec()),
     }
 }
 
-fn build_scene_shape_chunk(chunk_content: CompleteByteSlice) -> Chunk {
+fn build_scene_shape_chunk(chunk_content: &[u8]) -> Chunk {
     match scene::parse_scene_shape(chunk_content) {
         Ok((_, shape_node)) => Chunk::ShapeNode(shape_node),
         _ => Chunk::Invalid(chunk_content.to_vec()),
     }
 }
 
-fn build_layer_chunk(chunk_content: CompleteByteSlice) -> Chunk {
+fn build_layer_chunk(chunk_content: &[u8]) -> Chunk {
     match scene::parse_layer(chunk_content) {
         Ok((_, layer)) => Chunk::Layer(layer),
         _ => Chunk::Invalid(chunk_content.to_vec()),
@@ -249,8 +375,9 @@ pub fn parse_material(i: &[u8]) -> IResult<&[u8], Material> {
     Ok((i, Material { id, properties }))
 }
 
-fn parse_dict(i: &[u8]) -> IResult<&[u8], Dict> {
+pub fn parse_dict(i: &[u8]) -> IResult<&[u8], Dict> {
     let (i, n) = le_u32(i)?;
+
     let init = move || Dict::with_capacity(n as usize);
     let fold = |mut map: Dict, (key, value)| {
         map.insert(key, value);


### PR DESCRIPTION
* Update to nom 7 (with Scene graph support - PR https://github.com/davidedmonds/dot_vox/pull/22)
* Helper methods included for querying material properties
* Update unit tests for these changes, including doctests (PR https://github.com/davidedmonds/dot_vox/pull/25)
* Helper methods included for parsing rotations and positions within frames
* Fix some clippy lints
* Rust edition 2021 (https://github.com/davidedmonds/dot_vox/pull/24)
* Add some comments regarding a possible inconsistency with the PACK chunk as described in the spec
  * This chunk does not seem to be used anymore in newer MagicaVoxel versions