### PR TITLE
Make `clippy` happy, bring back `AHash` feature, cleanup/clarify docs, `cargo fmt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ homepage = "https://docs.rs/dot_vox"
 repository = "https://github.com/dust-engine/dot_vox"
 readme = "README.md"
 
+[features]
+default = ["ahash"]
+
 [dependencies]
 byteorder = "^1.4.3"
 lazy_static = "^1.4"
 log = "^0.4"
 nom = { version = "^7", default-features = false, features = ["alloc"] }
+ahash = { version = "^0.8", optional = true }
 
 [dev-dependencies]
 avow = "0.2.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+edition = "2021"
+unstable_features = true
+use_field_init_shorthand = true
+reorder_impl_items = true
+wrap_comments = true
+format_code_in_doc_comments = true

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -1,16 +1,16 @@
 use crate::{Layer, Material, Model, SceneNode};
 use std::io::{self, Write};
 
-/// Container for .vox file data
+/// Container for `.vox` file data.
 #[derive(Debug, PartialEq, Eq)]
 pub struct DotVoxData {
-    /// The version number of the .vox file.
+    /// The version number of the `.vox` file.
     pub version: u32,
-    /// A Vec of all the models contained within this file.
+    /// A `Vec` of all the models contained within this file.
     pub models: Vec<Model>,
-    /// A Vec containing the colour palette as 32-bit integers
+    /// A `Vec` containing the colour palette as 32-bit integers
     pub palette: Vec<u32>,
-    /// A Vec containing all the Materials set
+    /// A `Vec` containing all the [`Material`]s set.
     pub materials: Vec<Material>,
     /// Scene. The first node in this list is always the root node.
     pub scenes: Vec<SceneNode>,
@@ -19,7 +19,7 @@ pub struct DotVoxData {
 }
 
 impl DotVoxData {
-    /// Serializes `self` in the VOX format.
+    /// Serializes `self` in the `.vox` format.
     /// TODO: write the material set
     pub fn write_vox<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         self.write_header(writer)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,10 @@
 //! Load MagicaVoxel .vox files into Rust
-extern crate byteorder;
 #[cfg(test)]
 extern crate env_logger;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate nom;
 
 #[cfg(test)]
 extern crate avow;
@@ -121,7 +119,6 @@ pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
 ///
 /// ```
 /// use dot_vox::*;
-/// use std::collections::HashMap;
 ///
 /// let result = load_bytes(include_bytes!("resources/placeholder.vox"));
 /// assert_eq!(result.unwrap(), DotVoxData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-//! Load MagicaVoxel .vox files into Rust
+//! Load [MagicaVoxel](https://ephtracy.github.io/) `.vox` files from Rust.
+use parser::parse_vox_file;
+use std::{fs::File, io::Read};
+
 #[cfg(test)]
 extern crate env_logger;
 #[macro_use]
@@ -27,23 +30,21 @@ pub use scene::*;
 
 pub use palette::DEFAULT_PALETTE;
 
-use parser::parse_vox_file;
-
-use std::fs::File;
-use std::io::Read;
-
-/// Loads the supplied MagicaVoxel .vox file
+/// Loads the supplied [MagicaVoxel](https://ephtracy.github.io/) `.vox` file
 ///
-/// Loads the supplied file, parses it, and returns a `DotVoxData` containing
-/// the version of the MagicaVoxel file, a `Vec<Model>` containing all `Model`s
-/// contained within the file, a `Vec<u32>` containing the palette information
-/// (RGBA), and a `Vec<Material>` containing all the specialized materials.
+/// Loads the supplied file, parses it, and returns a [`DotVoxData`] containing
+/// the version of the MagicaVoxel file, a `Vec<`[`Model`]`>` containing all
+/// [`Model`]s contained within the file, a `Vec<u32>` containing the palette
+/// information (RGBA), and a `Vec<`[`Material`]`>` containing all the
+/// specialized materials.
 ///
 /// # Panics
-/// No panics should occur with this library - if you find one, please raise a
-/// GitHub issue for it.
+///
+/// No panics should occur with this library -- if you find one, please raise a
+/// [GitHub issue](https://github.com/dust-engine/dot_vox/issues) for it.
 ///
 /// # Errors
+///
 /// All errors are strings, and should describe the issue that caused them to
 /// occur.
 ///
@@ -53,40 +54,61 @@ use std::io::Read;
 ///
 /// ```
 /// use dot_vox::*;
-/// use std::collections::HashMap;
 ///
 /// let result = load("src/resources/placeholder.vox");
-/// assert_eq!(result.unwrap(), DotVoxData {
-///   version: 150,
-///   models: vec!(
-///     Model {
-///       size: Size { x: 2, y: 2, z: 2 },
-///       voxels: vec!(
-///         Voxel { x: 0, y: 0, z: 0, i: 225 },
-///         Voxel { x: 0, y: 1, z: 1, i: 215 },
-///         Voxel { x: 1, y: 0, z: 1, i: 235 },
-///         Voxel { x: 1, y: 1, z: 0, i: 5 }
-///       )
+/// assert_eq!(
+///     result.unwrap(),
+///     DotVoxData {
+///         version: 150,
+///         models: vec!(Model {
+///             size: Size { x: 2, y: 2, z: 2 },
+///             voxels: vec!(
+///                 Voxel {
+///                     x: 0,
+///                     y: 0,
+///                     z: 0,
+///                     i: 225
+///                 },
+///                 Voxel {
+///                     x: 0,
+///                     y: 1,
+///                     z: 1,
+///                     i: 215
+///                 },
+///                 Voxel {
+///                     x: 1,
+///                     y: 0,
+///                     z: 1,
+///                     i: 235
+///                 },
+///                 Voxel {
+///                     x: 1,
+///                     y: 1,
+///                     z: 0,
+///                     i: 5
+///                 }
+///             )
+///         }),
+///         palette: DEFAULT_PALETTE.to_vec(),
+///         materials: (0..256)
+///             .into_iter()
+///             .map(|i| Material {
+///                 id: i,
+///                 properties: {
+///                     let mut map = Dict::new();
+///                     map.insert("_ior".to_owned(), "0.3".to_owned());
+///                     map.insert("_spec".to_owned(), "0.5".to_owned());
+///                     map.insert("_rough".to_owned(), "0.1".to_owned());
+///                     map.insert("_type".to_owned(), "_diffuse".to_owned());
+///                     map.insert("_weight".to_owned(), "1".to_owned());
+///                     map
+///                 }
+///             })
+///             .collect(),
+///         scenes: placeholder::SCENES.to_vec(),
+///         layers: placeholder::LAYERS.to_vec(),
 ///     }
-///   ),
-///   palette: DEFAULT_PALETTE.to_vec(),
-///   materials: (0..256).into_iter()
-///     .map(|i| Material {
-///       id: i,
-///       properties: {
-///         let mut map = Dict::new();
-///         map.insert("_ior".to_owned(), "0.3".to_owned());
-///         map.insert("_spec".to_owned(), "0.5".to_owned());
-///         map.insert("_rough".to_owned(), "0.1".to_owned());
-///         map.insert("_type".to_owned(), "_diffuse".to_owned());
-///         map.insert("_weight".to_owned(), "1".to_owned());
-///         map
-///       }
-///     })
-///     .collect(),
-///   scenes: placeholder::SCENES.to_vec(),
-///   layers: placeholder::LAYERS.to_vec(),
-///   });
+/// );
 /// ```
 pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
     match File::open(filename) {
@@ -101,15 +123,19 @@ pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
 
 /// Parses the byte array as a .vox file.
 ///
-/// Parses the byte array and returns a `DotVoxData` containing  the version of the MagicaVoxel
-/// file, a `Vec<Model>` containing all `Model`s contained within the file, a `Vec<u32>` containing
-/// the palette information (RGBA), and a `Vec<Material>` containing all the specialized materials.
+/// Parses the byte array and returns a [`DotVoxData`] containing  the version
+/// of the MagicaVoxel file, a `Vec<`[`Model`]`>` containing all `Model`s
+/// contained within the file, a `Vec<u32>` containing the palette information
+/// (RGBA), and a `Vec<`[`Material`]`>` containing all the specialized
+/// materials.
 ///
 /// # Panics
-/// No panics should occur with this library - if you find one, please raise a
-/// GitHub issue for it.
+///
+/// No panics should occur with this library -- if you find one, please raise a
+/// [GitHub issue](https://github.com/dust-engine/dot_vox/issues) for it.
 ///
 /// # Errors
+///
 /// All errors are strings, and should describe the issue that caused them to
 /// occur.
 ///
@@ -121,37 +147,59 @@ pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
 /// use dot_vox::*;
 ///
 /// let result = load_bytes(include_bytes!("resources/placeholder.vox"));
-/// assert_eq!(result.unwrap(), DotVoxData {
-///   version: 150,
-///   models: vec!(
-///     Model {
-///       size: Size { x: 2, y: 2, z: 2 },
-///       voxels: vec!(
-///         Voxel { x: 0, y: 0, z: 0, i: 225 },
-///         Voxel { x: 0, y: 1, z: 1, i: 215 },
-///         Voxel { x: 1, y: 0, z: 1, i: 235 },
-///         Voxel { x: 1, y: 1, z: 0, i: 5 }
-///       )
+/// assert_eq!(
+///     result.unwrap(),
+///     DotVoxData {
+///         version: 150,
+///         models: vec!(Model {
+///             size: Size { x: 2, y: 2, z: 2 },
+///             voxels: vec!(
+///                 Voxel {
+///                     x: 0,
+///                     y: 0,
+///                     z: 0,
+///                     i: 225
+///                 },
+///                 Voxel {
+///                     x: 0,
+///                     y: 1,
+///                     z: 1,
+///                     i: 215
+///                 },
+///                 Voxel {
+///                     x: 1,
+///                     y: 0,
+///                     z: 1,
+///                     i: 235
+///                 },
+///                 Voxel {
+///                     x: 1,
+///                     y: 1,
+///                     z: 0,
+///                     i: 5
+///                 }
+///             )
+///         }),
+///         palette: DEFAULT_PALETTE.to_vec(),
+///         materials: (0..256)
+///             .into_iter()
+///             .map(|i| Material {
+///                 id: i,
+///                 properties: {
+///                     let mut map = Dict::new();
+///                     map.insert("_ior".to_owned(), "0.3".to_owned());
+///                     map.insert("_spec".to_owned(), "0.5".to_owned());
+///                     map.insert("_rough".to_owned(), "0.1".to_owned());
+///                     map.insert("_type".to_owned(), "_diffuse".to_owned());
+///                     map.insert("_weight".to_owned(), "1".to_owned());
+///                     map
+///                 }
+///             })
+///             .collect(),
+///         scenes: placeholder::SCENES.to_vec(),
+///         layers: placeholder::LAYERS.to_vec(),
 ///     }
-///   ),
-///   palette: DEFAULT_PALETTE.to_vec(),
-///   materials: (0..256).into_iter()
-///     .map(|i| Material {
-///       id: i,
-///       properties: {
-///         let mut map = Dict::new();
-///         map.insert("_ior".to_owned(), "0.3".to_owned());
-///         map.insert("_spec".to_owned(), "0.5".to_owned());
-///         map.insert("_rough".to_owned(), "0.1".to_owned());
-///         map.insert("_type".to_owned(), "_diffuse".to_owned());
-///         map.insert("_weight".to_owned(), "1".to_owned());
-///         map
-///       }
-///     })
-///     .collect(),
-///   scenes: placeholder::SCENES.to_vec(),
-///   layers: placeholder::LAYERS.to_vec(),
-///   });
+/// );
 /// ```
 pub fn load_bytes(bytes: &[u8]) -> Result<DotVoxData, &'static str> {
     match parse_vox_file(bytes) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 //! Load MagicaVoxel .vox files into Rust
-
 extern crate byteorder;
 #[cfg(test)]
 extern crate env_logger;
@@ -216,8 +215,6 @@ pub mod placeholder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
     use avow::vec;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,27 +1,27 @@
-use nom::multi::count;
-use nom::number::complete::{le_u32, le_u8};
-use nom::sequence::tuple;
-use nom::IResult;
+use nom::{
+    multi::count,
+    number::complete::{le_u32, le_u8},
+    sequence::tuple,
+    IResult,
+};
 
-/// A renderable voxel Model
+/// A renderable voxel model.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Model {
-    /// The size of the model in voxels
+    /// The size of the model in voxels.
     pub size: Size,
     /// The voxels to be displayed.
     pub voxels: Vec<Voxel>,
 }
 
 impl Model {
-    /// Number of bytes when encoded in VOX format.
+    /// Number of bytes when encoded in `.vox` format.
     pub fn num_vox_bytes(&self) -> u32 {
         12 + 4 * self.voxels.len() as u32
     }
 }
 
-/// The size of a model in voxels
-///
-/// Indicates the size of the model in Voxels.
+/// The dimensions of a model in voxels.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Size {
     /// The width of the model in voxels.
@@ -32,21 +32,22 @@ pub struct Size {
     pub z: u32,
 }
 
-/// A Voxel
+/// A voxel.
 ///
-/// A Voxel is a point in 3D space, with an indexed colour attached.
+/// A point in 3D space, with an indexed color attached.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Voxel {
-    /// The X coordinate for the Voxel
+    /// The X coordinate for the voxel.
     pub x: u8,
-    /// The Y coordinate for the Voxel
+    /// The Y coordinate for the voxel.
     pub y: u8,
-    /// The Z coordinate for the Voxel
+    /// The Z coordinate for the voxel.
     pub z: u8,
-    /// Index in the Color Palette. Note that this will be 1 less than the value stored in the
-    /// source file, as the palette indices run from 1-255, whereas in memory the indices run from
-    /// 0-254. Therefore, to make life easier, we store the in-memory index here. Should you require
-    /// the source file's indices, simply add 1 to this value.
+    /// Index in the color palette. Note that this will be oen less than the
+    /// value stored in the source file, as the palette indices run from
+    /// 1--255, whereas in memory the indices run from 0--254. Therefore, to
+    /// make life easier, we store the in-memory index here. Should you
+    /// require the source file's indices, simply add 1 to this value.
     pub i: u8,
 }
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,12 +1,9 @@
 use byteorder::{ByteOrder, LittleEndian};
-use nom::combinator::all_consuming;
-use nom::multi::many0;
-use nom::number::complete::le_u32;
-use nom::IResult;
+use nom::{combinator::all_consuming, multi::many0, number::complete::le_u32, IResult};
 
 lazy_static! {
-  /// The default palette used by MagicaVoxel - this is supplied if no palette
-  /// is included in the .vox file.
+  /// The default palette used by [MagicaVoxel](https://ephtracy.github.io/) -- this is supplied if no palette
+  /// is included in the `.vox` file.
   pub static ref DEFAULT_PALETTE: Vec<u32> =
     include_bytes!("resources/default_palette.bytes")
         .chunks(4)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -56,7 +56,7 @@ impl Material {
     pub fn weight(&self) -> Option<f32> {
         let w = self.get_f32("_weight");
 
-        if let Some(w) = w && (w < 0.0 || w > 1.0)
+        if let Some(w) = w && !(0.0..=1.0).contains(&w)
         {
             debug!("_weight observed outside of range of [0..1]: {}", w);
         }
@@ -203,7 +203,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                             frames: scene_transform
                                 .frames
                                 .into_iter()
-                                .map(|attributes| Frame::new(attributes))
+                                .map(Frame::new)
                                 .collect(),
                             child: scene_transform.child,
                         });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,18 +1,22 @@
 use crate::{
-    model, palette, scene, DotVoxData, Layer, Model, SceneGroup, SceneNode, SceneShape,
-    SceneTransform, Size, Voxel, DEFAULT_PALETTE,
+    model, palette, scene, DotVoxData, Frame, Layer, Model, RawLayer, SceneGroup, SceneNode,
+    SceneShape, SceneTransform, Size, Voxel, DEFAULT_PALETTE,
 };
-use nom::bytes::complete::{tag, take};
-use nom::combinator::{flat_map, map_res};
-use nom::multi::{fold_many_m_n, many0};
-use nom::number::complete::le_u32;
-use nom::sequence::pair;
-use nom::IResult;
-use std::collections::HashMap;
-use std::str;
-use std::str::Utf8Error;
+use nom::{
+    bytes::complete::{tag, take},
+    combinator::{flat_map, map_res},
+    multi::{fold_many_m_n, many0},
+    number::complete::le_u32,
+    sequence::pair,
+    IResult,
+};
+use std::{str, str::Utf8Error};
 
-use crate::{Frame, RawLayer};
+#[cfg(feature = "ahash")]
+use ahash::AHashMap as HashMap;
+
+#[cfg(not(feature = "ahash"))]
+use std::collections::HashMap;
 
 const MAGIC_NUMBER: &str = "VOX ";
 
@@ -43,7 +47,7 @@ pub struct Material {
 
 // TODO: maybe material schemas?
 impl Material {
-    /// The '_type' field, if present
+    /// The `_type` field, if present
     pub fn material_type(&self) -> Option<&str> {
         if let Some(t) = self.properties.get("_type") {
             return Some(t.as_str());
@@ -52,93 +56,107 @@ impl Material {
         None
     }
 
-    /// The '_weight' field associated with the material
+    /// The `_weight` field associated with the material
     pub fn weight(&self) -> Option<f32> {
         let w = self.get_f32("_weight");
 
-        if let Some(w) = w && !(0.0..=1.0).contains(&w)
-        {
+        if let Some(w) = w && !(0.0..=1.0).contains(&w) {
             debug!("_weight observed outside of range of [0..1]: {}", w);
         }
 
         w
     }
 
-    /// The '_metal' field associated with the material
-    pub fn metal(&self) -> Option<f32> {
+    /// The `_metal` field associated with the material
+    pub fn metalness(&self) -> Option<f32> {
         self.get_f32("_metal")
     }
 
-    /// The '_rough' field associated with the material
+    /// The `_rough` field associated with the material
     pub fn roughness(&self) -> Option<f32> {
         self.get_f32("_rough")
     }
 
-    /// The '_sp' field associated with the material.
-    /// The .vox specification lists this as "_spec".
+    /// The `_sp` field associated with the material.
     pub fn specular(&self) -> Option<f32> {
         self.get_f32("_sp")
     }
 
-    /// The '_ior' field associated with the material
+    /// The `_ior` field associated with the material
     pub fn refractive_index(&self) -> Option<f32> {
         self.get_f32("_ior")
     }
 
-    /// The '_emit' field associated with the material
-    pub fn emit(&self) -> Option<f32> {
+    /// The `_emit` field associated with the material
+    pub fn emission(&self) -> Option<f32> {
         self.get_f32("_emit")
     }
 
-    /// The '_ldr' field associated with the material
-    pub fn ldr(&self) -> Option<f32> {
+    /// The '_ldr' field associated with the material. This is a 'hack' factor
+    /// to scale emissive materials visually by so they look less bright when
+    /// rendered. I.e. this blends between the actual color of the resp.
+    /// voxel (`low_dynamic_range_scale` = 0) and its pure diffuse color
+    /// (`low_dynamic_range_scale` = 1)
+    pub fn low_dynamic_range_scale(&self) -> Option<f32> {
         self.get_f32("_ldr")
     }
 
-    /// The '_ri' field associated with the material (appears to just be 1 + _ior)
+    /// The '_ri' field associated with the material (appears to just be 1 +
+    /// _ior)
     pub fn ri(&self) -> Option<f32> {
         self.get_f32("_ior")
     }
 
-    /// The '_att' field associated with the material
-    pub fn att(&self) -> Option<f32> {
+    /// The `_att` field associated with the `glass` material.
+    ///
+    /// This is the falloff that models the optiocal density of the medium.
+    pub fn attenuation(&self) -> Option<f32> {
         self.get_f32("_att")
     }
 
-    /// The '_flux' field associated with the material
-    pub fn flux(&self) -> Option<f32> {
+    /// The `_flux` field associated with the `emissive` material.
+    pub fn radiant_flux(&self) -> Option<f32> {
         self.get_f32("_flux")
     }
 
-    /// The '_g' field associated with the material
+    /// The `_g` field associated with the material.
     pub fn phase(&self) -> Option<f32> {
         self.get_f32("_g")
     }
 
-    /// The '_alpha' field associated with the material
-    pub fn alpha(&self) -> Option<f32> {
+    /// The `_alpha` field associated with the material.
+    ///
+    /// This is the alpha/blending value that is used to blend the voxel with
+    /// the background (compositing related, has no relation to physics).
+    pub fn opacity(&self) -> Option<f32> {
         self.get_f32("_alpha")
     }
 
-    /// The '_trans' field associated with the material.
-    /// Appears to share the same meaning as _alpha.
+    /// The `_trans` field associated with the material.
+    ///
+    /// This is the transparency of the material. I.e. a physical property,
+    /// honours [`refractive_index()`](Material::refractive_index), see above.
     pub fn transparency(&self) -> Option<f32> {
         self.get_f32("_trans")
     }
 
-    /// The '_d' field associated with the material
+    /// The `_d` field associated with the `cloud` material.
+    ///
+    /// This is the density of the volumetric medium.
     pub fn density(&self) -> Option<f32> {
         self.get_f32("_d")
     }
 
-    /// The '_media' field associated with the material.
-    /// This corresponds to the 'cloud' material.
+    /// The `_media` field associated with the material.
+    /// This corresponds to the `cloud` material.
     pub fn media(&self) -> Option<f32> {
         self.get_f32("_media")
     }
 
-    /// The '_media_type' field associated with the material.
-    /// Corresponds to the type of cloud: absorb, scatter, emissive, subsurface scattering
+    /// The `_media_type` field associated with the material.
+    ///
+    /// Corresponds to the type of `cloud`: `absorb`, `scatter`, `emissive`,
+    /// `subsurface scattering`
     pub fn media_type(&self) -> Option<&str> {
         if let Some(t) = self.properties.get("_media_type") {
             return Some(t.as_str());
@@ -161,7 +179,7 @@ impl Material {
     }
 }
 
-/// General dictionary
+/// General dictionary.
 pub type Dict = HashMap<String, String>;
 
 pub fn to_str(i: &[u8]) -> Result<String, Utf8Error> {
@@ -200,11 +218,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                     Chunk::TransformNode(scene_transform) => {
                         scene.push(SceneNode::Transform {
                             attributes: scene_transform.header.attributes,
-                            frames: scene_transform
-                                .frames
-                                .into_iter()
-                                .map(Frame::new)
-                                .collect(),
+                            frames: scene_transform.frames.into_iter().map(Frame::new).collect(),
                             child: scene_transform.child,
                         });
                     }
@@ -218,7 +232,8 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                     }),
                     Chunk::Layer(layer) => {
                         if layer.id as usize != layers.len() {
-                            // Not sure if this actually happens in practice, but nothing in the spec prohibits it.
+                            // Not sure if this actually happens in practice, but nothing in the
+                            // spec prohibits it.
                             debug!(
                                 "Unexpected layer id {} encountered, layers may be out of order.",
                                 layer.id
@@ -313,8 +328,9 @@ fn build_palette_chunk(chunk_content: &[u8]) -> Chunk {
     Chunk::Invalid(chunk_content.to_vec())
 }
 
-// NOTE: this does not seem consistent with the PACK documentation.  However, files with PACK chunks seem rare.
-// It's likely this hasn't been tested.  Is this correct?
+// NOTE: this does not seem consistent with the PACK documentation.  However,
+// files with PACK chunks seem rare. It's likely this hasn't been tested.  Is
+// this correct?
 fn build_pack_chunk(chunk_content: &[u8]) -> Chunk {
     if let Ok((chunk_content, Chunk::Size(size))) = parse_chunk(chunk_content) {
         if let Ok((_, Chunk::Voxels(voxels))) = parse_chunk(chunk_content) {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -280,8 +280,8 @@ impl Frame {
 
                 let mut index_nz3 = 0;
 
-                for i in 0..possible_thirds.len() {
-                    if possible_thirds[i] == false {
+                for (i, possible_third) in possible_thirds.iter().enumerate() {
+                    if !possible_third {
                         index_nz3 = i;
                     }
                 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,22 +1,26 @@
 use crate::Dict;
-use nom::number::complete::{le_i32, le_u32};
-use nom::sequence::tuple;
-use nom::{multi::count, sequence::pair, IResult};
+use nom::{
+    multi::count,
+    number::complete::{le_i32, le_u32},
+    sequence::pair,
+    sequence::tuple,
+    IResult,
+};
 
 use crate::parser::parse_dict;
 /// Node header.
 #[derive(Debug, PartialEq, Eq)]
 pub struct NodeHeader {
-    /// Id of this transform node
+    /// ID of this transform node.
     pub id: u32,
-    /// Attributes of this transform node
+    /// Attributes of this transform node.
     pub attributes: Dict,
 }
 
 /// A model reference in a shape node.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShapeModel {
-    /// Id of the model.
+    /// ID of the model.
     pub model_id: u32,
     /// Attributes of the model in this shape node.
     pub attributes: Dict,
@@ -42,66 +46,65 @@ impl ShapeModel {
 /// Transform node.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SceneTransform {
-    /// Header
+    /// Header.
     pub header: NodeHeader,
     /// 1 single child (appear to be always either a group or shape node)
     pub child: u32,
     /// Layer ID.
     pub layer_id: u32,
-    /// Positional Frames.
+    /// Positional frames.
     pub frames: Vec<Dict>,
 }
 
 /// Group node.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SceneGroup {
-    /// Header
+    /// Header.
     pub header: NodeHeader,
-    /// Multiple children (appear to be always transform nodes)
+    /// Multiple children (appear to be always transform nodes).
     pub children: Vec<u32>,
 }
 
 /// Shape node.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SceneShape {
-    /// Header
+    /// Header.
     pub header: NodeHeader,
-    /// 1 or more models
+    /// One or more models.
     pub models: Vec<ShapeModel>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-/// A color stored as RGB
+/// A color stored as sRGB.
 pub struct Color {
     r: u8,
     g: u8,
     b: u8,
 }
 
-/// Layer information (raw)
+/// Layer information (raw).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawLayer {
-    /// id of this layer.
+    /// ID of this layer.
     pub id: u32,
-
-    /// Attributes of this layer
+    /// Attributes of this layer.
     pub attributes: Dict,
 }
 
-/// Layer information
+/// Layer information.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Layer {
-    /// Attributes of this layer
+    /// Attributes of this layer.
     pub attributes: Dict,
 }
 
 impl Layer {
-    /// Return the name for this layer, if it exists
+    /// Return the name for this layer, if it exists.
     pub fn name(&self) -> Option<String> {
         self.attributes.get("_name").cloned()
     }
 
-    /// Return whether this layer is hidden (layers are visible by default)
+    /// Return whether this layer is hidden (layers are visible by default).
     pub fn hidden(&self) -> bool {
         if let Some(x) = self.attributes.get("_hidden") {
             return x == "1";
@@ -110,7 +113,7 @@ impl Layer {
         false
     }
 
-    /// Return the color associated with this layer, if one has been set
+    /// Return the color associated with this layer, if one has been set.
     pub fn color(&self) -> Option<Color> {
         if let Some(x) = self.attributes.get("_color") {
             if let IResult::<&str, (u8, &str, u8, &str, u8)>::Ok((_, (r, _, g, _, b))) =
@@ -134,6 +137,7 @@ impl Layer {
         None
     }
 }
+
 fn parse_node_header(i: &[u8]) -> IResult<&[u8], NodeHeader> {
     let (i, (id, attributes)) = pair(le_u32, parse_dict)(i)?;
     Ok((i, NodeHeader { id, attributes }))
@@ -188,14 +192,15 @@ pub fn parse_layer(i: &[u8]) -> IResult<&[u8], RawLayer> {
     let (i, _ignored) = le_u32(i)?;
     Ok((i, RawLayer { id, attributes }))
 }
+
 /// Represents a translation. Used to position a chunk relative to other chunks.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Position {
-    /// The X coordinate for the Translation
+    /// The X coordinate of the translation.
     pub x: i32,
-    /// The Y coordinate for the Translation
+    /// The Y coordinate of the translation.
     pub y: i32,
-    /// The Z coordinate for the Translation
+    /// The Z coordinate of the translation.
     pub z: i32,
 }
 
@@ -216,30 +221,34 @@ impl From<Position> for (i32, i32, i32) {
 }
 
 /// Represents a rotation.  Used to orient a chunk relative to other chunks.
-/// The rotation is represented as a row-major 3x3 matrix (this is how it appears in the .vox format).
+/// The rotation is represented as a row-major 3×3 matrix (this is how it
+/// appears in the `.vox` format).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Rotation {
-    /// This is a row-major representation of the rotation as an orthonormal 3x3 matrix.
-    /// The entries are in [-1..1].
+    /// This is a row-major representation of the rotation as an orthonormal 3×3
+    /// matrix. The entries are in [-1..1].
     rot: [[i8; 3]; 3],
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
-/// Represents an animation.  The chunk is oriented according to the rotation ('_r') is placed at the position ('t') specified.
-/// The Rotation is instantaneous and happens at the start of the Frame.
-/// The animation is interpolated across the sequence of Frames using their positions.
+/// Represents an animation.  The chunk is oriented according to the rotation
+/// (`_r`) is placed at the position (`t`) specified. The Rotation is
+/// instantaneous and happens at the start of the frame. The animation is
+/// interpolated across the sequence of Frames using their positions.
 pub struct Frame {
     /// The raw attributes as parsed from the .vox
     attributes: Dict,
 }
 
 impl Frame {
-    /// Build a new frame from a set of attributes.  Note that construction is lazy; parsing happens at query time.
+    /// Build a new frame from a set of attributes.  Note that construction is
+    /// lazy; parsing happens at query time.
     pub fn new(attributes: Dict) -> Frame {
         Frame { attributes }
     }
 
-    /// The "_r" field in the .vox spec.  Represents the orientation of the model.
+    /// The `_r` field in the `.vox` spec.  Represents the orientation of the
+    /// model.
     pub fn orientation(&self) -> Option<Rotation> {
         if let Some(value) = self.attributes.get("_r") {
             if let IResult::<&str, u8>::Ok((_, byte_rotation)) =
@@ -271,7 +280,8 @@ impl Frame {
                     return None;
                 }
 
-                // You get the third index out via a process of elimination here. It's the one that wasn't used for the other rows.
+                // You get the third index out via a process of elimination here. It's the one
+                // that wasn't used for the other rows.
                 let possible_thirds = [
                     index_nz1 == 0 || index_nz2 == 0,
                     index_nz1 == 1 || index_nz2 == 1,
@@ -319,7 +329,8 @@ impl Frame {
         None
     }
 
-    /// The "_t" field in the .vox spec.  Represents the position of this frame begins in world space.
+    /// The `_t` field in the `.vox` spec.  Represents the position of this
+    /// frame begins in world space.
     pub fn position(&self) -> Option<Position> {
         if let Some(value) = self.attributes.get("_t") {
             match tuple((
@@ -342,7 +353,8 @@ impl Frame {
         None
     }
 
-    /// The "_f" field in the .vox spec.  Represents the frame number that this keyframe is located at.
+    /// The `_f` field in the .vox spec.  Represents the frame number that this
+    /// keyframe is located at.
     pub fn frame_index(&self) -> Option<u32> {
         if let Some(value) = self.attributes.get("_f") {
             if let IResult::<&str, u32>::Ok((_, frame_idx)) =
@@ -357,7 +369,8 @@ impl Frame {
     }
 }
 
-/// Scene graph nodes for representing a scene in DotVoxData.
+/// Scene graph nodes for representing a scene in
+/// [`DotVoxData`](crate::dot_vox_data::DotVoxData).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SceneNode {
     /// Transform Node Chunk (nTRN)
@@ -366,14 +379,14 @@ pub enum SceneNode {
         attributes: Dict,
         /// Transform frames.
         frames: Vec<Frame>,
-        /// Child node of this Transform node.
+        /// Child node of this transform node.
         child: u32,
     },
     /// Group Node Chunk (nGRP)
     Group {
         /// Attributes.
         attributes: Dict,
-        /// Child nodes
+        /// Child nodes.
         children: Vec<u32>,
     },
     /// Shape Node Chunk (nSHP)


### PR DESCRIPTION
See subject. Basically everything that was lost from the recent merging mashup and then some.