### PR TITLE
Added Color, layer_id, Rotation arithmetics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ ahash = { version = "^0.8", optional = true }
 
 [dev-dependencies]
 avow = "0.2.0"
+glam = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 default = ["ahash"]
 
 [dependencies]
-byteorder = "^1.4.3"
 lazy_static = "^1.4"
 log = "^0.4"
 nom = { version = "^7", default-features = false, features = ["alloc"] }
@@ -23,4 +22,3 @@ ahash = { version = "^0.8", optional = true }
 
 [dev-dependencies]
 avow = "0.2.0"
-env_logger = "^0.9"

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -1,4 +1,4 @@
-use crate::{Layer, Material, Model, SceneNode};
+use crate::{Color, Layer, Material, Model, SceneNode};
 use std::io::{self, Write};
 
 /// Container for `.vox` file data.
@@ -9,7 +9,7 @@ pub struct DotVoxData {
     /// A `Vec` of all the models contained within this file.
     pub models: Vec<Model>,
     /// A `Vec` containing the colour palette as 32-bit integers
-    pub palette: Vec<u32>,
+    pub palette: Vec<Color>,
     /// A `Vec` containing all the [`Material`]s set.
     pub materials: Vec<Material>,
     /// Scene. The first node in this list is always the root node.
@@ -92,7 +92,8 @@ impl DotVoxData {
     fn write_palette_chunk<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
         let mut chunk = Vec::new();
         for color in self.palette.iter() {
-            chunk.extend_from_slice(&color.to_le_bytes());
+            let color: [u8; 4] = color.into();
+            chunk.extend_from_slice(&color);
         }
 
         Self::write_leaf_chunk(writer, "RGBA", &chunk)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 use parser::parse_vox_file;
 use std::{fs::File, io::Read};
 
-#[cfg(test)]
-extern crate env_logger;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -29,6 +27,7 @@ pub use model::Voxel;
 
 pub use scene::*;
 
+pub use palette::Color;
 pub use palette::DEFAULT_PALETTE;
 
 /// Loads the supplied [MagicaVoxel](https://ephtracy.github.io/) `.vox` file
@@ -285,7 +284,7 @@ mod tests {
     }
 
     fn placeholder(
-        palette: Vec<u32>,
+        palette: Vec<Color>,
         materials: Vec<Material>,
         scenes: Vec<SceneNode>,
         layers: Vec<Layer>,
@@ -393,7 +392,6 @@ mod tests {
 
     #[test]
     fn can_parse_vox_file_with_materials() {
-        env_logger::init();
         let bytes = include_bytes!("resources/placeholder-with-materials.vox").to_vec();
         let result = super::parse_vox_file(&bytes);
         assert!(result.is_ok());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@ mod model;
 mod palette;
 mod parser;
 mod scene;
+mod types;
+
+pub use types::Rotation;
 
 pub use dot_vox_data::DotVoxData;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,8 @@ pub mod placeholder {
             SceneNode::Transform {
                 attributes: Dict::new(),
                 frames: vec![Frame::default()], // Is this true??  Why empty dict? FIXME
-                child: 1
+                child: 1,
+                layer_id: 4294967295
             },
             SceneNode::Group {
                 attributes: Dict::new(),
@@ -234,6 +235,7 @@ pub mod placeholder {
                     vec![Frame::new(map)]
                 },
                 child: 3,
+                layer_id: 0
             },
             SceneNode::Shape {
                 attributes: Dict::new(),

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,16 +1,40 @@
-use byteorder::{ByteOrder, LittleEndian};
-use nom::{combinator::all_consuming, multi::many0, number::complete::le_u32, IResult};
+use nom::sequence::tuple;
+use nom::{combinator::all_consuming, multi::many0, number::complete::le_u8, IResult};
 
 lazy_static! {
   /// The default palette used by [MagicaVoxel](https://ephtracy.github.io/) -- this is supplied if no palette
   /// is included in the `.vox` file.
-  pub static ref DEFAULT_PALETTE: Vec<u32> =
+  pub static ref DEFAULT_PALETTE: Vec<Color> =
     include_bytes!("resources/default_palette.bytes")
         .chunks(4)
-        .map(LittleEndian::read_u32)
+        .map(|bytes| parse_color(bytes).unwrap().1)
         .collect();
 }
 
-pub fn extract_palette(i: &[u8]) -> IResult<&[u8], Vec<u32>> {
-    all_consuming(many0(le_u32))(i)
+pub fn extract_palette(i: &[u8]) -> IResult<&[u8], Vec<Color>> {
+    all_consuming(many0(parse_color))(i)
+}
+
+fn parse_color(input: &[u8]) -> IResult<&[u8], Color> {
+    let (input, (r, g, b, a)) = tuple((le_u8, le_u8, le_u8, le_u8))(input)?;
+    Ok((input, Color { r, g, b, a }))
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+impl From<Color> for [u8; 4] {
+    fn from(color: Color) -> Self {
+        [color.r, color.g, color.b, color.a]
+    }
+}
+impl From<&Color> for [u8; 4] {
+    fn from(color: &Color) -> Self {
+        [color.r, color.g, color.b, color.a]
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -220,6 +220,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
                             attributes: scene_transform.header.attributes,
                             frames: scene_transform.frames.into_iter().map(Frame::new).collect(),
                             child: scene_transform.child,
+                            layer_id: scene_transform.layer_id,
                         });
                     }
                     Chunk::GroupNode(scene_group) => scene.push(SceneNode::Group {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    model, palette, scene, DotVoxData, Frame, Layer, Model, RawLayer, SceneGroup, SceneNode,
+    model, palette, scene, Color, DotVoxData, Frame, Layer, Model, RawLayer, SceneGroup, SceneNode,
     SceneShape, SceneTransform, Size, Voxel, DEFAULT_PALETTE,
 };
 use nom::{
@@ -26,7 +26,7 @@ pub enum Chunk {
     Size(Size),
     Voxels(Vec<Voxel>),
     Pack(Model),
-    Palette(Vec<u32>),
+    Palette(Vec<Color>),
     Material(Material),
     TransformNode(SceneTransform),
     GroupNode(SceneGroup),
@@ -199,7 +199,7 @@ fn map_chunk_to_data(version: u32, main: Chunk) -> DotVoxData {
         Chunk::Main(children) => {
             let mut size_holder: Option<Size> = None;
             let mut models: Vec<Model> = vec![];
-            let mut palette_holder: Vec<u32> = DEFAULT_PALETTE.to_vec();
+            let mut palette_holder: Vec<Color> = DEFAULT_PALETTE.to_vec();
             let mut materials: Vec<Material> = vec![];
             let mut scene: Vec<SceneNode> = vec![];
             let mut layers: Vec<Layer> = Vec::new();

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -381,6 +381,8 @@ pub enum SceneNode {
         frames: Vec<Frame>,
         /// Child node of this transform node.
         child: u32,
+        /// Layer ID
+        layer_id: u32,
     },
     /// Group Node Chunk (nGRP)
     Group {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,4 +1,4 @@
-use crate::Dict;
+use crate::{Color, Dict};
 use nom::{
     multi::count,
     number::complete::{le_i32, le_u32},
@@ -74,14 +74,6 @@ pub struct SceneShape {
     pub models: Vec<ShapeModel>,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-/// A color stored as sRGB.
-pub struct Color {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
 /// Layer information (raw).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawLayer {
@@ -125,7 +117,7 @@ impl Layer {
                     nom::character::complete::u8,
                 ))(x.as_str())
             {
-                return Some(Color { r, g, b });
+                return Some(Color { r, g, b, a: 0 });
             } else {
                 debug!(
                     "Encountered _color attribute in layer that appears to be malformed: {}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,269 @@
+/// A **[`Signed Permutation Matrix`]** [^note] encoded in a byte.
+///
+/// # Encoding
+/// The encoding follows the MagicaVoxel [ROTATION] type.
+///
+/// for example :
+/// ```
+/// let R = [
+///   [0,  1,  0],
+///   [0,  0, -1],
+///   [-1, 0,  0],
+/// ];
+/// let _r: u8 = (1 << 0) | (2 << 2) | (0 << 4) | (1 << 5) | (1 << 6);
+/// ```
+///
+/// | bit | value |                  descripton                             |
+/// |-----|-------|---------------------------------------------------------|
+/// | 0-1 |   1   | Index of the non-zero entry in the first row            |
+/// | 2-3 |   2   | Index of the non-zero entry in the second row           |
+/// |  4  |   0   | The sign in the first row (0 - positive; 1 - negative)|
+/// |  5  |   1   | The sign in the second row  (0 - positive; 1 - negative)|
+/// |  6  |   1   | The sign in the third row  (0 - positive; 1 - negative) |
+///
+/// [`Signed Permutation Matrix`]: https://en.wikipedia.org/wiki/Generalized_permutation_matrix#Signed_permutation_group
+/// [ROTATION]: https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox-extension.txt#L24
+/// [^note]: A [`Signed Permutation Matrix`] is a square binary matrix that has exactly one entry of ±1 in each row and each column and 0s elsewhere.
+#[derive(Clone, Copy)]
+pub struct Rotation(u8);
+
+pub type Quat = [f32; 4];
+pub type Vec3 = [f32; 3];
+
+impl Rotation {
+    pub const IDENTITY: Self = Rotation(0b0000100);
+
+    pub fn from_byte(byte: u8) -> Self {
+        let index_nz1 = byte & 0b11;
+        let index_nz2 = (byte >> 2) & 0b11;
+        assert!(
+            (index_nz1 != index_nz2) && (index_nz1 != 0b11 && index_nz2 != 0b11),
+            "Invalid Rotation"
+        );
+        Rotation(byte)
+    }
+
+    /// Decompose the Signed Permutation Matrix into a rotation component, represented by a Quaternion,
+    /// and a flip component, represented by a Vec3 which is either Vec3::ONE or -Vec3::ONE.
+    pub fn to_quat_scale(&self) -> (Quat, Vec3) {
+        let index_nz1 = self.0 & 0b11;
+        let index_nz2 = (self.0 >> 2) & 0b11;
+        let flip = (self.0 >> 4) as usize;
+
+        let si = [1.0, 1.0, 1.0]; // scale_identity
+        let sf = [-1.0, -1.0, -1.0]; // scale_flip
+        const SQRT_2_2: f32 = std::f32::consts::SQRT_2 / 2.0;
+        match (index_nz1, index_nz2) {
+            (0, 1) => {
+                let quats = [
+                    [0.0, 0.0, 0.0, 1.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [1.0, 0.0, 0.0, 0.0],
+                ];
+                let mapping = [0, 3, 2, 1, 1, 2, 3, 0];
+                let scales = [si, sf, sf, si, sf, si, si, sf];
+                (quats[mapping[flip]], scales[flip])
+            }
+            (0, 2) => {
+                let quats = [
+                    [0.0, SQRT_2_2, SQRT_2_2, 0.0],
+                    [SQRT_2_2, 0.0, 0.0, SQRT_2_2],
+                    [SQRT_2_2, 0.0, 0.0, -SQRT_2_2],
+                    [0.0, SQRT_2_2, -SQRT_2_2, 0.0],
+                ];
+                let mapping = [3, 0, 1, 2, 2, 1, 0, 3];
+                let scales = [sf, si, si, sf, si, sf, sf, si];
+                (quats[mapping[flip]], scales[flip])
+            }
+            (1, 2) => {
+                let quats = [
+                    [0.5, 0.5, 0.5, -0.5],
+                    [0.5, -0.5, 0.5, 0.5],
+                    [0.5, -0.5, -0.5, -0.5],
+                    [0.5, 0.5, -0.5, 0.5],
+                ];
+                let mapping = [0, 3, 2, 1, 1, 2, 3, 0];
+                let scales = [si, sf, sf, si, sf, si, si, sf];
+                (quats[mapping[flip]], scales[flip])
+            }
+            (1, 0) => {
+                let quats = [
+                    [0.0, 0.0, SQRT_2_2, SQRT_2_2],
+                    [0.0, 0.0, SQRT_2_2, -SQRT_2_2],
+                    [SQRT_2_2, SQRT_2_2, 0.0, 0.0],
+                    [SQRT_2_2, -SQRT_2_2, 0.0, 0.0],
+                ];
+                let mapping = [3, 0, 1, 2, 2, 1, 0, 3];
+                let scales = [sf, si, si, sf, si, sf, sf, si];
+
+                (quats[mapping[flip]], scales[flip])
+            }
+            (2, 0) => {
+                let quats = [
+                    [0.5, 0.5, 0.5, 0.5],
+                    [0.5, -0.5, -0.5, 0.5],
+                    [0.5, 0.5, -0.5, -0.5],
+                    [0.5, -0.5, 0.5, -0.5],
+                ];
+                let mapping = [0, 3, 2, 1, 1, 2, 3, 0];
+                let scales = [si, sf, sf, si, sf, si, si, sf];
+                (quats[mapping[flip]], scales[flip])
+            }
+            (2, 1) => {
+                let quats = [
+                    [0.0, SQRT_2_2, 0.0, -SQRT_2_2],
+                    [SQRT_2_2, 0.0, SQRT_2_2, 0.0],
+                    [0.0, SQRT_2_2, 0.0, SQRT_2_2],
+                    [SQRT_2_2, 0.0, -SQRT_2_2, 0.0],
+                ];
+                let mapping = [3, 0, 1, 2, 2, 1, 0, 3];
+                let scales = [sf, si, si, sf, si, sf, sf, si];
+                (quats[mapping[flip]], scales[flip])
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn to_cols_array_2d(&self) -> [[f32; 3]; 3] {
+        let mut cols: [[f32; 3]; 3] = [[0.0; 3]; 3];
+
+        let index_nz1 = self.0 & 0b11;
+        let index_nz2 = (self.0 >> 2) & 0b11;
+        let index_nz3 = 3 - index_nz1 - index_nz2;
+
+        let row_1_sign: f32 = if self.0 & (1 << 4) == 0 { 1.0 } else { -1.0 };
+        let row_2_sign: f32 = if self.0 & (1 << 5) == 0 { 1.0 } else { -1.0 };
+        let row_3_sign: f32 = if self.0 & (1 << 6) == 0 { 1.0 } else { -1.0 };
+
+        cols[index_nz1 as usize][0] = row_1_sign;
+        cols[index_nz2 as usize][1] = row_2_sign;
+        cols[index_nz3 as usize][2] = row_3_sign;
+
+        cols
+    }
+}
+
+impl std::fmt::Debug for Rotation {
+    /// Print the Rotation in a format that looks like `Rotation(-y, -z, x)`
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
+        let index_nz1 = self.0 & 0b11;
+        let index_nz2 = (self.0 >> 2) & 0b11;
+        let index_nz3 = 3 - index_nz1 - index_nz2;
+
+        let xyz: &[char; 3] = &['x', 'y', 'z'];
+
+        f.write_str("Rotation(")?;
+
+        if self.0 & (1 << 4) != 0 {
+            f.write_char('-')?;
+        };
+        f.write_char(xyz[index_nz1 as usize])?;
+        f.write_char(' ')?;
+
+        if self.0 & (1 << 5) != 0 {
+            f.write_char('-')?;
+        };
+        f.write_char(xyz[index_nz2 as usize])?;
+        f.write_char(' ')?;
+
+        if self.0 & (1 << 6) != 0 {
+            f.write_char('-')?;
+        };
+        f.write_char(xyz[index_nz3 as usize])?;
+        f.write_char(')')?;
+        Ok(())
+    }
+}
+
+impl std::ops::Mul<Rotation> for Rotation {
+    type Output = Rotation;
+
+    /// Integer-only multiplication of two Rotation.
+    fn mul(self, rhs: Rotation) -> Rotation {
+        let mut rhs_rows = [rhs.0 & 0b11, (rhs.0 >> 2) & 0b11, 0];
+        rhs_rows[2] = 3 - rhs_rows[0] - rhs_rows[1];
+
+        let mut lhs_rows = [self.0 & 0b11, (self.0 >> 2) & 0b11, 0];
+        lhs_rows[2] = 3 - lhs_rows[0] - lhs_rows[1];
+        let lhs_signs = self.0 >> 4;
+
+        let result_row_0 = rhs_rows[lhs_rows[0] as usize];
+        let result_row_1 = rhs_rows[lhs_rows[1] as usize];
+        let rhs_signs = rhs.0 >> 4;
+
+        let rhs_signs_0 = (rhs_signs >> lhs_rows[0]) & 1;
+        let rhs_signs_1 = (rhs_signs >> lhs_rows[1]) & 1;
+        let rhs_signs_2 = (rhs_signs >> lhs_rows[2]) & 1;
+        let rhs_signs_permutated: u8 = rhs_signs_0 | (rhs_signs_1 << 1) | (rhs_signs_2 << 2);
+        let signs = lhs_signs ^ rhs_signs_permutated;
+        Rotation(result_row_0 | (result_row_1 << 2) | (signs << 4))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_spm_mul() {
+        use super::Rotation as SPM;
+        let spms: [u8; 6] = [0b0001, 0b0010, 0b0100, 0b0110, 0b1000, 0b1001];
+
+        // Test for every possible spms
+        for i in 0..6 {
+            for j in 0..6 {
+                for sign_i in 0..8 {
+                    for sign_j in 0..8 {
+                        let spm_lhs = SPM(spms[i] | (sign_i << 4));
+                        let spm_rhs = SPM(spms[j] | (sign_j << 4));
+                        let spm_mul = spm_lhs * spm_rhs;
+                        let spm_mul_mat: glam::Mat3 =
+                            glam::Mat3::from_cols_array_2d(&spm_mul.to_cols_array_2d());
+
+                        let spm_lhs_mat: glam::Mat3 =
+                            glam::Mat3::from_cols_array_2d(&spm_lhs.to_cols_array_2d());
+                        let spm_rhs_mat: glam::Mat3 =
+                            glam::Mat3::from_cols_array_2d(&spm_rhs.to_cols_array_2d());
+
+                        // Compare the result of the integer-only multiplication with the
+                        // result of the f32 matrix multiplication
+                        let spm_reference_result: glam::Mat3 = spm_lhs_mat * spm_rhs_mat;
+                        assert_eq!(spm_mul_mat, spm_reference_result);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_to_quat_scale() {
+        use super::Rotation as SPM;
+        let spms: [u8; 6] = [0b0100, 0b1000, 0b1001, 0b0001, 0b0010, 0b0110];
+
+        // Test for every possible spms
+        for i in 0..6 {
+            for sign_i in 0..8 {
+                let spm = SPM(spms[i] | (sign_i << 4));
+                let (rotation, scale) = spm.to_quat_scale();
+                let rotation = glam::Quat::from_array(rotation);
+                let scale: glam::Vec3 = scale.into();
+                let rs_mat = glam::Mat3::from_quat(rotation)
+                    * glam::mat3(
+                        glam::Vec3::new(scale.x, 0.0, 0.0),
+                        glam::Vec3::new(0.0, scale.y, 0.0),
+                        glam::Vec3::new(0.0, 0.0, scale.z),
+                    );
+                let reference_mat: glam::Mat3 =
+                    glam::Mat3::from_cols_array_2d(&spm.to_cols_array_2d());
+                for i in 0..3 {
+                    for j in 0..3 {
+                        if (reference_mat.col(i)[j] - rs_mat.col(i)[j]).abs() > 0.00001 {
+                            println!("{:?} vs {:?}", rs_mat, reference_mat);
+                            panic!();
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added Color struct for palette
- Added layer_id
- Added rotation arithmetic. MagicaVoxel represents rotation with a byte. This implementation allows one to convert a byte rotation directly to the STR representation without going through the intermediate matrix.