### PR TITLE
Update CHANGELOG.md to describe 5.0.0 and 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+5.1.0
+=====
+
+- Added rotation type
+
+5.0.0
+=====
+
+- Added scenegraph support ([#23](https://github.com/dust-engine/dot_vox/pull/23))
+- Upgrade parser to nom 7
+- Upgrade to Rust 2021
+
 4.1.0
 =====
 


### PR DESCRIPTION
I noticed the CHANGELOG.md wasn't up to date so I thought I'd fix it. This is just the text of the GitHub release, copied into the changelog based on the commit history to match up to which is in 5.0.0 vs. 5.1.0 — I haven't looked harder than that.