### PR TITLE
Remove use of `let_chains` to restore compatibility with stable Rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Load [MagicaVoxel](https://ephtracy.github.io/) `.vox` files from Rust.
-#![feature(let_chains)]
+
 use parser::parse_vox_file;
 use std::{fs::File, io::Read};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -60,8 +60,10 @@ impl Material {
     pub fn weight(&self) -> Option<f32> {
         let w = self.get_f32("_weight");
 
-        if let Some(w) = w && !(0.0..=1.0).contains(&w) {
-            debug!("_weight observed outside of range of [0..1]: {}", w);
+        if let Some(w) = w {
+            if !(0.0..=1.0).contains(&w) {
+                debug!("_weight observed outside of range of [0..1]: {}", w);
+            }
         }
 
         w


### PR DESCRIPTION
`#![feature(let_chains)]` is preventing [the crates.io release 5.1.0](https://crates.io/crates/dot_vox) from being used with stable Rust. This PR removes the `feature` and the single use of `let_chains` so that the crate can compile on stable.

My project is currently using `dot_vox` version 4, so I'd appreciate if this PR could be merged and released as 5.1.1 so that I can update my dependency.

Fixes #35.