### PR TITLE
Fixed PACK implementation for read/write

### DIFF
--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -49,25 +49,11 @@ impl DotVoxData {
     }
 
     fn write_models<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        if self.models.len() > 1 {
-            self.write_pack_chunk(writer)?;
-        }
         for model in self.models.iter() {
             Self::write_model(writer, model)?;
         }
 
         Ok(())
-    }
-
-    fn write_pack_chunk<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {
-        let chunk = (self.models.len() as u32).to_le_bytes();
-
-        let mut num_children_bytes = 0;
-        for model in self.models.iter() {
-            num_children_bytes += model.num_vox_bytes();
-        }
-
-        Self::write_chunk(writer, "PACK", &chunk, num_children_bytes)
     }
 
     fn write_model<W: Write>(writer: &mut W, model: &Model) -> Result<(), io::Error> {

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,7 +17,11 @@ pub struct Model {
 impl Model {
     /// Number of bytes when encoded in `.vox` format.
     pub fn num_vox_bytes(&self) -> u32 {
-        12 + 4 * self.voxels.len() as u32
+        // The number 40 comes from:
+        // - 24 bytes for the chunk header format (SIZE/XYZI labels, chunk and child sizes, etc.)
+        // - 12 bytes for the SIZE contents (x, y, z)
+        // - 4 bytes for the voxel length u32
+        40 + 4 * self.voxels.len() as u32
     }
 }
 


### PR DESCRIPTION
While I was playing around with this module I came across (what I assume to be) a bug:

I wasn't able to `write_vox` to a file then immediately read it with `load`. To be a bit more specific, I was writing multiple models to the `.vox` file and when I would read it, the models array would be empty.

Turns out this is because `write_vox` uses `PACK` chunks and `load` is incorrectly loading the `PACK` chunks according to the [vox spec](https://github.com/ephtracy/voxel-model/blob/master/MagicaVoxel-file-format-vox.txt#L50). 

After I reimplemented that, I noticed that `num_vox_bytes` is incorrectly calculating the `PACK` chunk children length because it's missing 28 bytes per model. (Mostly because of headers detailed in the spec)

Anyways, this PR is intended to make the module parse/write `PACK` headers correctly. Feel free to critique the code as harshly as you want, I'm not that proficient in rust so there may be shorter ways to do things.