### PR TITLE
Set up for use of `cargo-fuzz`.

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dot_vox-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+dot_vox = { path = ".." }
+libfuzzer-sys = "0.4"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_load_bytes"
+path = "fuzz_targets/fuzz_load_bytes.rs"
+test = false
+doc = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,9 @@
+This package contains fuzz tests for `dot_vox`, which may detect cases where the
+parser panics (or even crashes, or allocates excessive memory) rather than
+returning an error.
+
+For more information on fuzz testing and how to run these tests, see
+[Rust Fuzz Book - Fuzzing with cargo-fuzz][1].
+
+
+[1]: https://rust-fuzz.github.io/book/cargo-fuzz.html

--- a/fuzz/fuzz_targets/fuzz_load_bytes.rs
+++ b/fuzz/fuzz_targets/fuzz_load_bytes.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // The fuzzer does not know or care what valid .vox data looks like.
+    // Therefore, this fuzz test can never _expect success;_ only expect failures to
+    // be reported via `Err` instead of panic.
+    let _ = dot_vox::load_bytes(data);
+});


### PR DESCRIPTION
This can be used with <https://crates.io/crates/cargo-fuzz> to fuzz test the parser, validating that it does not panic, crash, or allocate gigabytes of memory given arbitrary input.