### PR TITLE
Bug: Transform nodes orientation reference

### DIFF
--- a/examples/traverse_graph.rs
+++ b/examples/traverse_graph.rs
@@ -61,7 +61,7 @@ fn iterate_vox_tree_inner(
                             .expect("Expected valid u8 byte to parse rotation matrix"),
                     )
             } else {
-                rotation
+                Rotation::IDENTITY
             };
 
             iterate_vox_tree_inner(vox_tree, *child, translation, rotation, fun);


### PR DESCRIPTION
This is a tricky bug because it's only apparent when a model is complicated enough to have rotations in a multi-level node hierarchy. Basically discovered this through importing the castle voxel model, and the tree branches were unaligned in the import without this change.