### PR TITLE
Add support for IMAP chunks

### DIFF
--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -6,6 +6,10 @@ use std::io::{self, Write};
 pub struct DotVoxData {
     /// The version number of the `.vox` file.
     pub version: u32,
+    /// A mapping from [`crate::model::Voxel::i`] values to palette indices. In
+    /// the MagicaVoxel editor, this table gets reordered when dragging
+    /// palette entries around with control-click.
+    pub index_map: Vec<u8>,
     /// A `Vec` of all the models contained within this file.
     pub models: Vec<Model>,
     /// A `Vec` containing the colour palette as 32-bit integers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub use model::Voxel;
 pub use scene::*;
 
 pub use palette::Color;
+pub use palette::DEFAULT_INDEX_MAP;
 pub use palette::DEFAULT_PALETTE;
 
 /// Loads the supplied [MagicaVoxel](https://ephtracy.github.io/) `.vox` file
@@ -92,6 +93,7 @@ pub use palette::DEFAULT_PALETTE;
 ///                 }
 ///             )
 ///         }),
+///         index_map: DEFAULT_INDEX_MAP.to_vec(),
 ///         palette: DEFAULT_PALETTE.to_vec(),
 ///         materials: (0..256)
 ///             .into_iter()
@@ -183,6 +185,7 @@ pub fn load(filename: &str) -> Result<DotVoxData, &'static str> {
 ///                 }
 ///             )
 ///         }),
+///         index_map: DEFAULT_INDEX_MAP.to_vec(),
 ///         palette: DEFAULT_PALETTE.to_vec(),
 ///         materials: (0..256)
 ///             .into_iter()
@@ -265,6 +268,8 @@ pub mod placeholder {
 
 #[cfg(test)]
 mod tests {
+    use crate::palette::DEFAULT_INDEX_MAP;
+
     use super::*;
     use avow::vec;
 
@@ -323,6 +328,7 @@ mod tests {
                     },
                 ],
             }],
+            index_map: DEFAULT_INDEX_MAP.to_vec(),
             palette,
             materials,
             scenes,

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,3 +1,4 @@
+use nom::bytes::complete::take;
 use nom::sequence::tuple;
 use nom::{combinator::all_consuming, multi::many0, number::complete::le_u8, IResult};
 
@@ -9,6 +10,14 @@ lazy_static! {
         .chunks(4)
         .map(|bytes| parse_color(bytes).unwrap().1)
         .collect();
+}
+
+/// The default index map, that sends [`crate::model::Voxel::i`] values to
+/// corresponding palette slots.
+pub const DEFAULT_INDEX_MAP: &[u8] = &create_default_index_map();
+
+pub fn extract_index_map(i: &[u8]) -> IResult<&[u8], &[u8]> {
+    all_consuming(take(256usize))(i)
 }
 
 pub fn extract_palette(i: &[u8]) -> IResult<&[u8], Vec<Color>> {
@@ -37,4 +46,15 @@ impl From<&Color> for [u8; 4] {
     fn from(color: &Color) -> Self {
         [color.r, color.g, color.b, color.a]
     }
+}
+
+/// Creates an identity index map.
+const fn create_default_index_map() -> [u8; 256] {
+    let mut result = [0; 256];
+    let mut i = 0;
+    while i < result.len() {
+        result[i] = i.wrapping_add(1) as u8;
+        i += 1;
+    }
+    result
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,11 +5,7 @@
 ///
 /// for example :
 /// ```
-/// let R = [
-///   [0,  1,  0],
-///   [0,  0, -1],
-///   [-1, 0,  0],
-/// ];
+/// let R = [[0, 1, 0], [0, 0, -1], [-1, 0, 0]];
 /// let _r: u8 = (1 << 0) | (2 << 2) | (0 << 4) | (1 << 5) | (1 << 6);
 /// ```
 ///
@@ -43,8 +39,9 @@ impl Rotation {
         Rotation(byte)
     }
 
-    /// Decompose the Signed Permutation Matrix into a rotation component, represented by a Quaternion,
-    /// and a flip component, represented by a Vec3 which is either Vec3::ONE or -Vec3::ONE.
+    /// Decompose the Signed Permutation Matrix into a rotation component,
+    /// represented by a Quaternion, and a flip component, represented by a
+    /// Vec3 which is either Vec3::ONE or -Vec3::ONE.
     pub fn to_quat_scale(&self) -> (Quat, Vec3) {
         let index_nz1 = self.0 & 0b11;
         let index_nz2 = (self.0 >> 2) & 0b11;


### PR DESCRIPTION
In the MagicaVoxel editor, the order in which palette entries appear doesn't actually correspond to the palette index stored per-voxel. Instead, there is an "index map" indirection table, [as described here](https://github.com/ephtracy/voxel-model/blob/8044f9eb086216f3485cdaa525a52120d72274e9/MagicaVoxel-file-format-vox-extension.txt#L159-L165). When using this crate, I would like to be able to discern the user-displayed index for each palette entry, so I need to be able to read this data. This didn't look like it was already supported, so I have added the ability to read the index map.

For reference, here's [another `.vox` reader implementation that uses the index map to reorder the palette](https://github.com/jpaver/opengametools/blob/master/src/ogt_vox.h#L2174-L2208).