### PR TITLE
Bump nom to 8 and Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dot_vox"
-edition = "2021"
-version = "5.1.1"
+edition = "2024"
+version = "5.2.0"
 authors = ["David Edmonds <edmonds.d.r@gmail.com>"]
 description = "A Rust library for loading MagicaVoxel .vox files."
 license = "MIT"
@@ -15,11 +15,11 @@ readme = "README.md"
 default = ["ahash"]
 
 [dependencies]
-lazy_static = "^1.4"
+lazy_static = "^1.5"
 log = "^0.4"
-nom = { version = "^7", default-features = false, features = ["alloc"] }
+nom = { version = "^8", default-features = false, features = ["alloc"] }
 ahash = { version = "^0.8", optional = true }
 
 [dev-dependencies]
 avow = "0.2.0"
-glam = "0.21"
+glam = "0.31"

--- a/src/dot_vox_data.rs
+++ b/src/dot_vox_data.rs
@@ -83,7 +83,7 @@ impl DotVoxData {
 
     fn write_string(buffer: &mut Vec<u8>, str: &String) {
         buffer.extend_from_slice(&((str.len() as u32).to_le_bytes()));
-        buffer.extend_from_slice(&str.as_bytes());
+        buffer.extend_from_slice(str.as_bytes());
     }
 
     fn write_dict(buffer: &mut Vec<u8>, dict: &Dict) {
@@ -115,8 +115,8 @@ impl DotVoxData {
                 children,
             } => {
                 id = "nGRP";
-                node_chunk.extend_from_slice(&(i as u32).to_le_bytes());
-                Self::write_dict(&mut node_chunk, &attributes);
+                node_chunk.extend_from_slice(&i.to_le_bytes());
+                Self::write_dict(&mut node_chunk, attributes);
                 node_chunk.extend_from_slice(&((children.len() as u32).to_le_bytes()));
                 for child in children {
                     node_chunk.extend_from_slice(&child.to_le_bytes());
@@ -129,8 +129,8 @@ impl DotVoxData {
                 attributes,
             } => {
                 id = "nTRN";
-                node_chunk.extend_from_slice(&(i as u32).to_le_bytes());
-                Self::write_dict(&mut node_chunk, &attributes);
+                node_chunk.extend_from_slice(&i.to_le_bytes());
+                Self::write_dict(&mut node_chunk, attributes);
                 node_chunk.extend_from_slice(&child.to_le_bytes());
                 node_chunk.extend_from_slice(&u32::MAX.to_le_bytes());
                 node_chunk.extend_from_slice(&layer_id.to_le_bytes());
@@ -141,8 +141,8 @@ impl DotVoxData {
             }
             SceneNode::Shape { attributes, models } => {
                 id = "nSHP";
-                node_chunk.extend_from_slice(&(i as u32).to_le_bytes());
-                Self::write_dict(&mut node_chunk, &attributes);
+                node_chunk.extend_from_slice(&i.to_le_bytes());
+                Self::write_dict(&mut node_chunk, attributes);
                 node_chunk.extend_from_slice(&(models.len() as u32).to_le_bytes());
                 for model in models {
                     node_chunk.extend_from_slice(&model.model_id.to_le_bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,6 @@ pub mod placeholder {
 
         /// Layers extracted from placeholder.vox
         pub static ref LAYERS: Vec<Layer> = (0..8)
-            .into_iter()
             .map(|layer| Layer {
                 attributes: {
                     let mut map = Dict::new();

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,7 @@
 use nom::{
+    IResult, Parser,
     multi::count,
-    number::complete::{le_u32, le_u8},
-    sequence::tuple,
-    IResult,
+    number::complete::{le_u8, le_u32},
 };
 
 use crate::parser::validate_count;
@@ -60,12 +59,12 @@ pub struct Voxel {
 }
 
 pub fn parse_size(i: &[u8]) -> IResult<&[u8], Size> {
-    let (i, (x, y, z)) = tuple((le_u32, le_u32, le_u32))(i)?;
+    let (i, (x, y, z)) = (le_u32, le_u32, le_u32).parse(i)?;
     Ok((i, Size { x, y, z }))
 }
 
 fn parse_voxel(input: &[u8]) -> IResult<&[u8], Voxel> {
-    let (input, (x, y, z, i)) = tuple((le_u8, le_u8, le_u8, le_u8))(input)?;
+    let (input, (x, y, z, i)) = (le_u8, le_u8, le_u8, le_u8).parse(input)?;
     Ok((
         input,
         Voxel {
@@ -78,7 +77,7 @@ fn parse_voxel(input: &[u8]) -> IResult<&[u8], Voxel> {
 }
 
 pub fn parse_voxels(i: &[u8]) -> IResult<&[u8], Vec<Voxel>> {
-    let (i, n) = le_u32(i)?;
+    let (i, n) = le_u32.parse(i)?;
     let n = validate_count(i, n, 4)?;
-    count(parse_voxel, n)(i)
+    count(parse_voxel, n).parse(i)
 }

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,6 +1,5 @@
 use nom::bytes::complete::take;
-use nom::sequence::tuple;
-use nom::{combinator::all_consuming, multi::many0, number::complete::le_u8, IResult};
+use nom::{IResult, Parser, combinator::all_consuming, multi::many0, number::complete::le_u8};
 
 lazy_static! {
   /// The default palette used by [MagicaVoxel](https://ephtracy.github.io/) -- this is supplied if no palette
@@ -17,15 +16,15 @@ lazy_static! {
 pub const DEFAULT_INDEX_MAP: &[u8] = &create_default_index_map();
 
 pub fn extract_index_map(i: &[u8]) -> IResult<&[u8], &[u8]> {
-    all_consuming(take(256usize))(i)
+    all_consuming(take(256usize)).parse(i)
 }
 
 pub fn extract_palette(i: &[u8]) -> IResult<&[u8], Vec<Color>> {
-    all_consuming(many0(parse_color))(i)
+    all_consuming(many0(parse_color)).parse(i)
 }
 
 fn parse_color(input: &[u8]) -> IResult<&[u8], Color> {
-    let (input, (r, g, b, a)) = tuple((le_u8, le_u8, le_u8, le_u8))(input)?;
+    let (input, (r, g, b, a)) = (le_u8, le_u8, le_u8, le_u8).parse(input)?;
     Ok((input, Color { r, g, b, a }))
 }
 


### PR DESCRIPTION
 This PR upgrades the parser from nom 7 to nom 8 and updates the Rust edition to 2024.

nom 8 introduces a significant API change from closure-based combinators to trait-based ones. The main change is that instead of `combinator(arg)(input)`, we now use `combinator(arg).parse(input)`.